### PR TITLE
Add emotion data extraction tasks with auto-create workflow

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -1,0 +1,50 @@
+name: Create Issues from Pending Tasks
+
+on:
+  push:
+    paths:
+      - 'pending-tasks/*.json'
+  workflow_dispatch:
+
+jobs:
+  create-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Issues from Pending Tasks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Process each JSON file in pending-tasks directory
+          for file in pending-tasks/*.json; do
+            if [ -f "$file" ]; then
+              echo "Processing $file"
+
+              # Read JSON and create issues
+              jq -c '.tasks[]' "$file" | while read -r task; do
+                title=$(echo "$task" | jq -r '.title')
+                body=$(echo "$task" | jq -r '.body // ""')
+                labels=$(echo "$task" | jq -r '.labels | join(",")')
+
+                echo "Creating issue: $title"
+                gh issue create \
+                  --title "$title" \
+                  --body "$body" \
+                  --label "$labels"
+              done
+            fi
+          done
+
+      - name: Cleanup processed files
+        run: |
+          if [ -d "pending-tasks" ] && [ "$(ls -A pending-tasks/*.json 2>/dev/null)" ]; then
+            rm pending-tasks/*.json
+            git config user.name "GitHub Actions Bot"
+            git config user.email "actions@github.com"
+            git add pending-tasks/
+            git commit -m "Cleanup: remove processed pending tasks" || true
+            git push || true
+          fi

--- a/pending-tasks/emotion-extraction-tasks.json
+++ b/pending-tasks/emotion-extraction-tasks.json
@@ -1,0 +1,19 @@
+{
+  "tasks": [
+    {
+      "title": "[Routine] emotionの組み合わせ品番データ抽出",
+      "labels": ["type:routine", "pillar:work", "priority:high", "status:today"],
+      "body": "## 概要\n月初の定期作業\n\n## 手順\n1. ローカルタスクマネージャーでバッチ実行\n2. SQL実行 → CSV出力\n3. PowerQueryでExcel集計\n4. お客様に提供\n\n## 実行タイミング\n毎月月初の稼働日"
+    },
+    {
+      "title": "[Routine] emotionの納期回答データ抽出",
+      "labels": ["type:routine", "pillar:work", "priority:high", "status:today"],
+      "body": "## 概要\n月初の定期作業\n\n## 手順\n1. ローカルタスクマネージャーでバッチ実行\n2. SQL実行 → CSV出力\n3. PowerQueryでExcel集計\n4. お客様に提供\n\n## 実行タイミング\n毎月月初の稼働日"
+    },
+    {
+      "title": "[Routine] emotionの注文業務ログデータ抽出",
+      "labels": ["type:routine", "pillar:work", "priority:high", "status:today"],
+      "body": "## 概要\n月初の定期作業\n\n## 手順\n1. ローカルタスクマネージャーでバッチ実行\n2. SQL実行 → CSV出力\n3. PowerQueryでExcel集計\n4. お客様に提供\n\n## 実行タイミング\n毎月月初の稼働日"
+    }
+  ]
+}


### PR DESCRIPTION
- Add GitHub Actions workflow to auto-create issues from pending-tasks/*.json
- Add 3 emotion data extraction tasks for monthly first business day:
  1. 組み合わせ品番データ抽出
  2. 納期回答データ抽出
  3. 注文業務ログデータ抽出

https://claude.ai/code/session_01MZXYN6bbezbDwZmGowC8DP